### PR TITLE
Improve diff

### DIFF
--- a/test/pitoco/core_test.clj
+++ b/test/pitoco/core_test.clj
@@ -1,10 +1,8 @@
 (ns pitoco.core-test
   (:require
-   [clojure.java.io :as io]
    [clojure.test :refer [deftest testing is]]
    [clojure.test.check.generators :as gen]
    [clojure.walk :as walk]
-   [lambdaisland.deep-diff2 :as ddiff]
    [malli.core :as m]
    [pitoco.core :as pit]
    matcher-combinators.test)
@@ -461,21 +459,19 @@
               :method :get
               :host "httpbin.org"
               :response-schema-diff
-              '[[[:path []]
-                 {:path []
-                  :schema
-                  [:map
-                   [:args :map]
-                   [:headers
-                    [:map
-                     [:Accept string?]
-                     [:Host string?]
-                     [:User-Agent string?]
-                     [:X-Amzn-Trace-Id string?]]]
-                   [:origin {:- string? :+ int?}]
-                   [:url string?]]}]
-                [[:path [:origin]]
-                 {:path [:origin] :schema {:- string? :+ int?}}]]
+              '{:type :map,
+                :children
+                [[:args nil {:type :map}]
+                 [:headers
+                  nil
+                  {:type :map,
+                   :children
+                   [[:Accept nil {:type string?}]
+                    [:Host nil {:type string?}]
+                    [:User-Agent nil {:type string?}]
+                    [:X-Amzn-Trace-Id nil {:type string?}]]}]
+                 [:origin nil {:type {:+ int?, :- string?}}]
+                 [:url nil {:type string?}]]}
               :request-schema-diff nil}]}
            (convert-ddiff
             (pit/process {::pit/pcap-path "resources-test/pcap-files/dump2.pcap"

--- a/web_app/backend/pitoco/server.clj
+++ b/web_app/backend/pitoco/server.clj
@@ -34,8 +34,12 @@
 
 (defn- pathom-handler
   [{:keys [body-params]}]
-  {:status 200
-   :body   (twrite (pathom (tread body-params)))})
+  (try
+    {:status 200
+     :body   (twrite (pathom (tread body-params)))}
+    (catch Exception e
+      (println e e)
+      (throw e))))
 
 (def ^:private pitoco-upload-sources-folder
   (io/file "../.pitoco/uploaded-sources"))

--- a/web_app/frontend/pitoco/events.cljs
+++ b/web_app/frontend/pitoco/events.cljs
@@ -41,12 +41,12 @@
                                        {:pitoco.core/pcap-path (:filepath source-base)})}))
                       [{:pitoco.core/api-schemas
                         ['*
-                         :pitoco.core/response-subschemas
-                         :pitoco.core/request-subschemas]}
+                         :pitoco.core/response-schema-map
+                         :pitoco.core/request-schema-map]}
                        {:pitoco.core/base [{:pitoco.core/api-schemas
                                             ['*
-                                             :pitoco.core/response-subschemas
-                                             :pitoco.core/request-subschemas]}]}
+                                             :pitoco.core/response-schema-map
+                                             :pitoco.core/request-schema-map]}]}
                        {:pitoco.core/api-schemas-diff
                         [:pitoco.api-schema/id
                          '*
@@ -58,8 +58,8 @@
                                      {:pitoco.core/pcap-path (:filepath source)}))
                       [{:pitoco.core/api-schemas
                         ['*
-                         :pitoco.core/response-subschemas
-                         :pitoco.core/request-subschemas]}]}])})
+                         :pitoco.core/response-schema-map
+                         :pitoco.core/request-schema-map]}]}])})
         :on-success [::fetch-source-success (assoc params :source source)]
         :on-failure [::fetch-source-failure]
         :format (ajax/transit-request-format)


### PR DESCRIPTION
The subschema diff is very error prone as it's based on the paths and
they can change easily as they are positional.

Solution is to use map schema for diff, it's much more well behaved
and the diffs are likely more helpful.